### PR TITLE
Improve coefficient generation

### DIFF
--- a/src/main/java/com/tiemens/secretshare/engine/SecretShare.java
+++ b/src/main/java/com/tiemens/secretshare/engine/SecretShare.java
@@ -684,13 +684,12 @@ public class SecretShare
     {
         for (int i = 1, n = coeffs.length; i < n; i++)
         {
-            BigInteger big = null;
-            //big = BigInteger.valueOf((random.nextInt() % 20) + 1);
-
-            big = BigInteger.valueOf(random.nextLong());
-            // ENHANCEMENT: provide better control?  make it even bigger?
-            // for now, we'll just do long^2:
-            big = big.multiply(BigInteger.valueOf(random.nextLong()));
+            BigInteger big;
+            if (modulus != null) {
+                big = new BigInteger(modulus.bitLength(), random);
+            } else {
+                big = new BigInteger(4096, random);
+            }
 
             // FIX? TODO:? FIX?
             big = big.abs(); // make it positive
@@ -702,9 +701,6 @@ public class SecretShare
             {
                 coeffs[i] = coeffs[i].mod(modulus);
             }
-
-            // FIX? TODO: FIX? experiment says "all coefficients are smaller than the secret"
-            coeffs[i] = coeffs[i].mod(secret);
         }
     }
 


### PR DESCRIPTION
Hey Tim,

I found a problem with the coefficient generation.

In this (https://gist.github.com/IwoTens/ff3559a88239ef4e4bc1688388ca32f9) gist I generate a 4096 bit secret thats just looping the alphabet.
When I print out the shares only the last few (~10 or so) bytes are obscured. The rest is still plainly visible. 
This is the case, since the coefficients have a maximum length of 128 bits (long * long).

This due to how the random BigIntegers are chosen. The patch allows the BigIntegers to be in the range from 0 to the modulus (or, if no modulus is available 4096 bits)

I've also removed the coeff %= secret, since I see no reason why this would be a requirement (and all tests successfully complete without any problem). For example, think about what happens if you have a very small secret (for example the number 2). The coefficient could then either be 0 or 1, drastically reducing the values of the polynomial (for no apparent reason).